### PR TITLE
fix hook_theme return value sample

### DIFF
--- a/app/templates/_module.php
+++ b/app/templates/_module.php
@@ -25,7 +25,7 @@ function <%= module_name %>_menu() {
 function <%= module_name %>_theme($existing, $type, $theme, $path) {
   $items = array();
   $items[''] = array(
-    'variable' => array(),
+    'variables' => array(),
     'path' => '',
     'template' => '',
   );


### PR DESCRIPTION
Corrected the array index name for `variables` in hook_theme return array.
