### PR TITLE
Fix UNMET PEER DEPENDENCY error

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,5 @@
     "coveralls": "^2.11.2",
     "istanbul": "^0.4.3",
     "mocha": "3.1.2"
-  },
-  "peerDependencies": {
-    "yo": ">=1.0.0"
   }
 }


### PR DESCRIPTION
When installing generator with npm3 user gets this error
from CLI and the installation process crashes although
yo is installed.

Fixes: #20